### PR TITLE
Update SemanticTextSplitter.class.ts to improve splitting sentences (especially for newline delimiter)

### DIFF
--- a/nodes/SemanticTextSplitter/SemanticTextSplitter.class.ts
+++ b/nodes/SemanticTextSplitter/SemanticTextSplitter.class.ts
@@ -60,7 +60,8 @@ export class SemanticTextSplitter extends TextSplitter implements SemanticTextSp
 		// Create regex pattern using the delimiters
 		const pattern = new RegExp(`[^${escapedDelimiters}]+[${escapedDelimiters}]+`, 'g');
 
-		return text.match(pattern) || [text];
+		return (text.match(pattern) || [text])
+			.map((sentence) => sentence.trim());
 	}
 
 	_createSlidingWindows(sentences: string[]): string[] {


### PR DESCRIPTION
trim splitted sentences to avoid leading and trailing spaces.